### PR TITLE
Fix compatibility with Clang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.dep
 .vscode
 linux*/
+darwin*/
 lnInclude/
 backup/
 *~

--- a/src/libSrc/fuelCellSystems/PhaseSystems/OneResistanceHeatTransferPhaseSystem/OneResistanceHeatTransferPhaseSystem.C
+++ b/src/libSrc/fuelCellSystems/PhaseSystems/OneResistanceHeatTransferPhaseSystem/OneResistanceHeatTransferPhaseSystem.C
@@ -302,9 +302,9 @@ heatTransfer
 
         if (phase1.name() == continuous)
         {
-            volScalarField dmdtCp = dmdt21*phase1.thermo().Cp().ref();
-            volScalarField dmdtKK = dmdt21*(K2 - K1);
-            volScalarField dmdthe = dmdt21*he2;
+            volScalarField dmdtCp(dmdt21*phase1.thermo().Cp().ref());
+            volScalarField dmdtKK(dmdt21*(K2 - K1));
+            volScalarField dmdthe(dmdt21*he2);
 
             dmdthe0.rmap(dmdthe, cellMap);
             dmdtCp0.rmap(dmdtCp, cellMap);
@@ -314,9 +314,9 @@ heatTransfer
         }
         else
         {
-            volScalarField dmdtCp = dmdt12*phase2.thermo().Cp().ref();
-            volScalarField dmdtKK = dmdt12*(K1 - K2);
-            volScalarField dmdthe = dmdt12*he1;
+            volScalarField dmdtCp(dmdt12*phase2.thermo().Cp().ref());
+            volScalarField dmdtKK(dmdt12*(K1 - K2));
+            volScalarField dmdthe(dmdt12*he1);
 
             dmdthe0.rmap(dmdthe, cellMap);
             dmdtCp0.rmap(dmdtCp, cellMap);

--- a/src/libSrc/fuelCellSystems/PhaseSystems/ThermalPhaseChangePhaseSystem/ThermalPhaseChangePhaseSystem.C
+++ b/src/libSrc/fuelCellSystems/PhaseSystems/ThermalPhaseChangePhaseSystem/ThermalPhaseChangePhaseSystem.C
@@ -310,7 +310,7 @@ Foam::ThermalPhaseChangePhaseSystem<BasePhaseSystem>::heatTransfer
 
             if (phase1.name() == continuous)
             {
-                const volScalarField wMDotL0 = negPart(*this->wMDotL_[pair]);
+                const volScalarField wMDotL0(negPart(*this->wMDotL_[pair]));
 
                 wMDotL.rmap(wMDotL0, cellMap);
 
@@ -318,7 +318,7 @@ Foam::ThermalPhaseChangePhaseSystem<BasePhaseSystem>::heatTransfer
             }
             else
             {
-                const volScalarField wMDotL0 = posPart(*this->wMDotL_[pair]);
+                const volScalarField wMDotL0(posPart(*this->wMDotL_[pair]));
 
                 wMDotL.rmap(wMDotL0, cellMap);
 

--- a/src/libSrc/fuelCellSystems/PhaseSystems/TwoResistanceHeatTransferPhaseSystem/TwoResistanceHeatTransferPhaseSystem.C
+++ b/src/libSrc/fuelCellSystems/PhaseSystems/TwoResistanceHeatTransferPhaseSystem/TwoResistanceHeatTransferPhaseSystem.C
@@ -426,15 +426,19 @@ Foam::TwoResistanceHeatTransferPhaseSystem<BasePhaseSystem>::heatTransfer
 
             if (phase1.name() == continuous)
             {
-                volScalarField dmdthe =
-                    dmdt21*phase1.thermo().he(phase1.thermo().p(), Tf);
+                volScalarField dmdthe
+                (
+                    dmdt21*phase1.thermo().he(phase1.thermo().p(), Tf)
+                );
 
                 dmdthe0.rmap(dmdthe, cellMap);
             }
             else
             {
-                volScalarField dmdthe =
-                    dmdt12*phase2.thermo().he(phase2.thermo().p(), Tf);
+                volScalarField dmdthe
+                (
+                    dmdt12*phase2.thermo().he(phase2.thermo().p(), Tf)
+                );
 
                 dmdthe0.rmap(dmdthe, cellMap);
             }
@@ -443,13 +447,13 @@ Foam::TwoResistanceHeatTransferPhaseSystem<BasePhaseSystem>::heatTransfer
         {
             if (phase1.name() == continuous)
             {
-                volScalarField dmdthe = dmdt21*he2;
+                volScalarField dmdthe(dmdt21*he2);
 
                 dmdthe0.rmap(dmdthe, cellMap);
             }
             else
             {
-                volScalarField dmdthe = dmdt12*he1;
+                volScalarField dmdthe(dmdt12*he1);
 
                 dmdthe0.rmap(dmdthe, cellMap);
             }
@@ -458,8 +462,8 @@ Foam::TwoResistanceHeatTransferPhaseSystem<BasePhaseSystem>::heatTransfer
 
         if (phase1.name() == continuous)
         {
-            volScalarField dmdtCp = dmdt21*phase1.thermo().Cp().ref();
-            volScalarField dmdtKK = dmdt21*(K2 - K1);
+            volScalarField dmdtCp(dmdt21*phase1.thermo().Cp().ref());
+            volScalarField dmdtKK(dmdt21*(K2 - K1));
 
             dmdtCp0.rmap(dmdtCp, cellMap);
             dmdtKK0.rmap(dmdtKK, cellMap);
@@ -468,8 +472,8 @@ Foam::TwoResistanceHeatTransferPhaseSystem<BasePhaseSystem>::heatTransfer
         }
         else
         {
-            volScalarField dmdtCp = dmdt12*phase2.thermo().Cp().ref();
-            volScalarField dmdtKK = dmdt12*(K1 - K2);
+            volScalarField dmdtCp(dmdt12*phase2.thermo().Cp().ref());
+            volScalarField dmdtKK(dmdt12*(K1 - K2));
 
             dmdtCp0.rmap(dmdtCp, cellMap);
             dmdtKK0.rmap(dmdtKK, cellMap);

--- a/src/libSrc/fuelCellSystems/dissolvedModels/standardDWModel/standardDWModel.C
+++ b/src/libSrc/fuelCellSystems/dissolvedModels/standardDWModel/standardDWModel.C
@@ -125,7 +125,7 @@ void Foam::dissolvedModels::standardDWModel::solve()
 {
     const volVectorField& i = mesh().lookupObject<volVectorField>(iName_);
 
-    surfaceScalarField phiI = fvc::interpolate(i) & mesh().Sf();
+    surfaceScalarField phiI(fvc::interpolate(i) & mesh().Sf());
 
     tmp<fvScalarMatrix> wEqn
     (
@@ -142,7 +142,7 @@ void Foam::dissolvedModels::standardDWModel::solve()
 
         // Update the water content
         // Water intake = water uptake
-        scalarField sum = source*volume;
+        scalarField sum(source*volume);
         scalar iDot(Foam::gSum(sum)/Foam::gSum(volume));
 
         for (label i = 0; i < lambda_.size(); i++)
@@ -164,7 +164,7 @@ void Foam::dissolvedModels::standardDWModel::correct()
 
     const scalarField& T = mesh().lookupObject<volScalarField>(TName_);
 
-    scalarField Dwm0 = Foam::exp(-2436/T)*corr_;
+    scalarField Dwm0(Foam::exp(-2436/T)*corr_);
 
     forAll(Dwm_, cellI)
     {

--- a/src/libSrc/fuelCellSystems/electroChemicalModel/electroChemicalReaction.C
+++ b/src/libSrc/fuelCellSystems/electroChemicalModel/electroChemicalReaction.C
@@ -146,11 +146,13 @@ void Foam::combustionModels::electroChemicalReaction<ReactionThermo>::correct()
     const scalarField& xH2O = phase.X(water);
 
     //- Activity
-    scalarField act0 =
+    scalarField act0
+    (
         xH2O
       * this->thermo_.p()
       / saturation_->pSat(thermo_.T()).ref()
-      + 2.*(scalar(1) - phase.primitiveField());
+      + 2.*(scalar(1) - phase.primitiveField())
+    );
 
     //- Only consider catalyst zone
     label znId = fluidPhase.cellZones().findZoneID(eta_->zoneName());

--- a/src/libSrc/fuelCellSystems/nernstModels/fixedValue/fixedValue.C
+++ b/src/libSrc/fuelCellSystems/nernstModels/fixedValue/fixedValue.C
@@ -63,7 +63,7 @@ void Foam::nernstModels::fixedValue<Thermo, OtherThermo>::correct()
     const scalarField& p = this->thermo_.p();
     const scalarField& T = this->thermo_.T();
 
-    scalarField pRef = p/this->pRef().value();
+    scalarField pRef(p/this->pRef().value());
 
     forAllConstIter(HashTable<scalar>, this->rxnList(), iter)
     {

--- a/src/libSrc/fuelCellSystems/nernstModels/standard/standard.C
+++ b/src/libSrc/fuelCellSystems/nernstModels/standard/standard.C
@@ -68,7 +68,7 @@ void Foam::nernstModels::standard<Thermo, OtherThermo>::correct()
     const scalarField& p = this->thermo_.p();
     const scalarField& T = this->thermo_.T();
 
-    scalarField pRef = p/this->pRef().value();
+    scalarField pRef(p/this->pRef().value());
 
     forAllConstIter(HashTable<scalar>, this->rxnList(), iter)
     {

--- a/src/libSrc/fuelCellSystems/porosityModel/DarcyForchheimer/DarcyForchheimer.C
+++ b/src/libSrc/fuelCellSystems/porosityModel/DarcyForchheimer/DarcyForchheimer.C
@@ -394,7 +394,7 @@ void Foam::porousZones::DarcyForchheimer::correctU
     const volScalarField& alpha2 = mesh_.lookupObject<volScalarField>(alpha2Name);
 
     //- temperary velocities
-    volVectorField U10 = dpcds & fvc::grad(alpha1);
+    volVectorField U10(dpcds & fvc::grad(alpha1));
 
     forAll(cellZoneIDs_, zoneI)
     {

--- a/src/libSrc/fuelCellSystems/regions/electric/electric.C
+++ b/src/libSrc/fuelCellSystems/regions/electric/electric.C
@@ -203,7 +203,7 @@ void Foam::regionTypes::electric::solve()
         //- Electro-Neutral, the total electron+proton flux should be zero
         const scalarField& source = j_;
         const scalarField& volume = this->V();
-        scalarField sum = source*volume;
+        scalarField sum(source*volume);
         scalar iDot(Foam::gSum(sum)/Foam::gSum(volume));
 
         for (label id = 0; id < nCells(); id++)
@@ -310,7 +310,7 @@ void Foam::regionTypes::electric::mapToCell
     Info << "Map " << name() << " to Cell " << nl << endl;
 
     //- heat source
-    volScalarField heatSource = (i_ & i_)/sigmaField_;
+    volScalarField heatSource((i_ & i_)/sigmaField_);
     volScalarField heatSource0
     (
         IOobject

--- a/src/libSrc/fuelCellSystems/regions/solid/solid.C
+++ b/src/libSrc/fuelCellSystems/regions/solid/solid.C
@@ -132,7 +132,7 @@ void Foam::regionTypes::solid::mapToCell
     //- rhoCpCell
     volScalarField& rhoCpCell = fuelCell.rhoCp();
 
-    scalarField rhoCp = rho*cp;
+    scalarField rhoCp(rho*cp);
 
     // Perform reverse mapping
     rhoCpCell.rmap(rhoCp, cellMapIO_);

--- a/src/libSrc/fuelCellSystems/solvers/driftFluxSystem/createFields.H
+++ b/src/libSrc/fuelCellSystems/solvers/driftFluxSystem/createFields.H
@@ -24,8 +24,8 @@ const volScalarField& psi1 = thermo1.psi();
 volScalarField& rho2 = thermo2.rho();
 const volScalarField& psi2 = thermo2.psi();
 
-volScalarField dmdt1 = phase1_.dmdt();
-volScalarField dmdt2 = phase2_.dmdt();
+volScalarField dmdt1(phase1_.dmdt());
+volScalarField dmdt2(phase2_.dmdt());
 
 fv::options& fvOptions = this->fvOptions();
 

--- a/src/libSrc/fuelCellSystems/solvers/driftFluxSystem/pU/pEqn.H
+++ b/src/libSrc/fuelCellSystems/solvers/driftFluxSystem/pU/pEqn.H
@@ -154,8 +154,8 @@ while (pimple.correct())
     // Add additional mass 
     // Mass transfer between regions
     {
-        volScalarField dmdt1 = phase1_.dmdt();
-        volScalarField dmdt2 = phase2_.dmdt();
+        volScalarField dmdt1(phase1_.dmdt());
+        volScalarField dmdt2(phase2_.dmdt());
 
         if (pEqnComp1.valid())
         {

--- a/src/libSrc/fuelCellSystems/solvers/singlePhaseSystem/createFields.H
+++ b/src/libSrc/fuelCellSystems/solvers/singlePhaseSystem/createFields.H
@@ -16,7 +16,7 @@ rhoThermo& thermo = phase_.thermoRef();
 volScalarField& p = thermo.p();
 volScalarField& rho = thermo.rho();
 const volScalarField& psi = thermo.psi();
-volScalarField dmdt = phase_.dmdt();
+volScalarField dmdt(phase_.dmdt());
 
 dimensionedScalar pMin
 (

--- a/src/libSrc/fuelCellSystems/solvers/twoPhaseSystem/createFieldRefs.H
+++ b/src/libSrc/fuelCellSystems/solvers/twoPhaseSystem/createFieldRefs.H
@@ -18,5 +18,5 @@ const volScalarField& psi1 = thermo1.psi();
 volScalarField& rho2 = thermo2.rho();
 const volScalarField& psi2 = thermo2.psi();
 
-volScalarField dmdt1 = phase1_.dmdt();
-volScalarField dmdt2 = phase2_.dmdt();
+volScalarField dmdt1(phase1_.dmdt());
+volScalarField dmdt2(phase2_.dmdt());

--- a/src/libSrc/interfacialCompositionModels/interfaceCompositionModels/NonRandomTwoLiquid/NonRandomTwoLiquid.C
+++ b/src/libSrc/interfacialCompositionModels/interfaceCompositionModels/NonRandomTwoLiquid/NonRandomTwoLiquid.C
@@ -78,26 +78,26 @@ NonRandomTwoLiquid
     (
         "alpha12",
         dimless,
-        dict.subDict(species1Name_).get<scalar>("alpha")
+        dict.subDict(species1Name_).template get<scalar>("alpha")
     );
     alpha21_ = dimensionedScalar
     (
         "alpha21",
         dimless,
-        dict.subDict(species2Name_).get<scalar>("alpha")
+        dict.subDict(species2Name_).template get<scalar>("alpha")
     );
 
     beta12_ = dimensionedScalar
     (
         "beta12",
         dimless/dimTemperature,
-        dict.subDict(species1Name_).get<scalar>("beta")
+        dict.subDict(species1Name_).template get<scalar>("beta")
     );
     beta21_ = dimensionedScalar
     (
         "beta21",
         dimless/dimTemperature,
-        dict.subDict(species2Name_).get<scalar>("beta")
+        dict.subDict(species2Name_).template get<scalar>("beta")
     );
 
     saturationModel12_.reset


### PR DESCRIPTION
Fixes compatibility with Clang by rewriting some field initializations and template member function usages that Clang finds ambiguous into a format that works okay with both Clang and GCC. This allows the package to be compiled with the Clang compiler (e.g. on macOS).